### PR TITLE
Conflict with the Redmine Graphs plugin

### DIFF
--- a/app/views/issues/_tags_sidebar.html.erb
+++ b/app/views/issues/_tags_sidebar.html.erb
@@ -1,4 +1,4 @@
-<% unless sidebar_tags.empty? -%>
+<% unless !defined?(sidebar_tags) || sidebar_tags.empty? -%>
   <%= stylesheet_link_tag 'jquery.tagit.css', :plugin => 'redmine_tags' %>
   <%= stylesheet_link_tag 'redmine_tags', :plugin => 'redmine_tags' %>
   <h3><%= l(:tags) %></h3>


### PR DESCRIPTION
Pages of [Redmine Graphs plugin](http://www.redmine.org/projects/redmine/wiki/PluginGraphs) are failing with following messages in the log:

```
Started GET "/projects/****/issues/graphs/bug_growth" for *.*.*.* at 2014-05-14 21:57:43 +0600
Processing by GraphsController#bug_growth as HTML
  Parameters: {"project_id"=>"****"}
  Current user: bsl_zcs (id=1)
  Rendered issues/_list_simple.html.erb (0.1ms)
  Rendered plugins/redmine_graphs/app/views/hooks/redmine_graphs/_view_issues_sidebar_issues_bottom.html.erb (1.0ms)
  Rendered plugins/redmine_tags/app/views/issues/_tags_sidebar.html.erb (80.7ms)
  Rendered issues/_sidebar.html.erb (83.6ms)
  Rendered plugins/redmine_graphs/app/views/graphs/bug_growth.html.erb within layouts/base (85.0ms)
Completed 500 Internal Server Error in 96.2ms

ActionView::Template::Error (undefined local variable or method `sidebar_tags' for #<#<Class:0x00000005d85248>:0x00000005d246f0>):
    1: <% unless sidebar_tags.empty? -%>
    2:   <%= stylesheet_link_tag 'jquery.tagit.css', :plugin => 'redmine_tags' %>
    3:   <%= stylesheet_link_tag 'redmine_tags', :plugin => 'redmine_tags' %>
    4:   <h3><%= l(:tags) %></h3>
  lib/redmine/hook.rb:111:in `block in render_on'
  lib/redmine/hook.rb:61:in `block (2 levels) in call_hook'
  lib/redmine/hook.rb:61:in `each'
  lib/redmine/hook.rb:61:in `block in call_hook'
  lib/redmine/hook.rb:58:in `tap'
  lib/redmine/hook.rb:58:in `call_hook'
  lib/redmine/hook.rb:158:in `call_hook'
  app/views/issues/_sidebar.html.erb:18:in `_app_views_issues__sidebar_html_erb___3410859086684596286_42962960'
```
